### PR TITLE
docs: minor renaming change in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To view or update your configuration:
 Alternatively, you can manually set these environment variables before starting the Gemini CLI:
 
 ```bash
-export KNOWLEDGE_CATALOG_PROJECT="<your-gcp-project-id>"
+export DATAPLEX_PROJECT="<your-gcp-project-id>"
 ```
 
 > [!NOTE]


### PR DESCRIPTION
Fixes the environment variable name in the README example to use DATAPLEX_PROJECT.